### PR TITLE
Misc cleanup

### DIFF
--- a/src/stationd/accessory.py
+++ b/src/stationd/accessory.py
@@ -20,30 +20,26 @@ class Accessory:
             GPIOPin(int(sd.config[config_section]['power_pin']), None, initial=None)
         )
 
-    def device_status(self, command_obj: 'sd.Command') -> None:
-        status = f'{command_obj.command[0]} power {sd.get_state(self.power)}\n'
-        sd.status_response(command_obj, status)
+    def device_status(self, command: list[str]) -> str:
+        return f'{command[0]} power {sd.get_state(self.power)}\n'
 
-    def component_status(self, command_obj: 'sd.Command') -> None:
+    def component_status(self, command: list[str]) -> str:
         try:
-            component = getattr(self, command_obj.command[1].replace('-', '_'))
+            component = getattr(self, command[1].replace('-', '_'))
         except AttributeError as error:
-            raise sd.InvalidCommandError(command_obj) from error
+            raise sd.InvalidCommandError from error
 
-        status = sd.get_status(component, command_obj)
-        sd.status_response(command_obj, status)
+        return sd.get_status(component, command)
 
-    def power_on(self, command_obj: 'sd.Command') -> None:
+    def power_on(self) -> None:
         if self.power.read() == sd.ON:
             raise sd.NoChangeError
         self.power.write(sd.ON)
-        sd.success_response(command_obj)
 
-    def power_off(self, command_obj: 'sd.Command') -> None:
+    def power_off(self) -> None:
         if self.power.read() == sd.OFF:
             raise sd.NoChangeError
         self.power.write(sd.OFF)
-        sd.success_response(command_obj)
 
 
 class VUTxRelay(Accessory):
@@ -53,25 +49,26 @@ class VUTxRelay(Accessory):
     paths.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, active_ptt: 'sd.ActivePTT') -> None:
         """Initialize the VHF/UHF TX Relay accessory.
 
         Sets up the VU TX relay with its configured GPIO power pin.
         """
         super().__init__('VU-TX-RELAY')
+        self.active_ptt = active_ptt
 
-    def _ptt_check(self, command_obj: 'sd.Command') -> None:
+    def _ptt_check(self) -> None:
         # VU TX Relay change cannot happen while any PTT is active
-        if command_obj.num_active_ptt > 0:
-            raise sd.PTTConflictError(command_obj)
+        if self.active_ptt.count > 0:
+            raise sd.PTTConflictError
 
-    def power_on(self, command_obj: 'sd.Command') -> None:
-        self._ptt_check(command_obj)
-        super().power_on(command_obj)
+    def power_on(self) -> None:
+        self._ptt_check()
+        super().power_on()
 
-    def power_off(self, command_obj: 'sd.Command') -> None:
-        self._ptt_check(command_obj)
-        super().power_off(command_obj)
+    def power_off(self) -> None:
+        self._ptt_check()
+        super().power_off()
 
 
 class SatnogsHost(Accessory):

--- a/src/stationd/amplifier.py
+++ b/src/stationd/amplifier.py
@@ -38,11 +38,16 @@ class TxAmplifier:
     That have a RF PTT (Push-To-Talk) switch and a power amplifier (PA).
     """
 
-    def __init__(self, active_ptt: 'sd.ActivePTT', rf_ptt_pin: int, pa_power_pin: int) -> None:
+    def __init__(self, active_ptt: 'sd.ActivePTT', section: str) -> None:
         """Initialize a new Amplifier instance."""
         self.active_ptt = active_ptt
-        self.rf_ptt = sd.assert_out(GPIOPin(rf_ptt_pin, None, initial=None))
-        self.pa_power = sd.assert_out(GPIOPin(pa_power_pin, None, initial=None))
+
+        self.rf_ptt = sd.assert_out(
+            GPIOPin(int(sd.config[section]['rf_ptt_pin']), None, initial=None)
+        )
+        self.pa_power = sd.assert_out(
+            GPIOPin(int(sd.config[section]['pa_power_pin']), None, initial=None)
+        )
 
         self.molly_guard_time = time.time() - MOLLY_TIME
         self.ptt_off_time = time.time() - PTT_COOLDOWN
@@ -112,20 +117,16 @@ class RxTxAmplifier(TxAmplifier):
     polarization switching.
     """
 
-    def __init__(  # noqa: PLR0913
-        self,
-        active_ptt: 'sd.ActivePTT',
-        rf_ptt_pin: int,
-        pa_power_pin: int,
-        tr_relay_pin: int,
-        lna_pin: int,
-        polarization_pin: int,
-    ) -> None:
+    def __init__(self, active_ptt: 'sd.ActivePTT', section: str) -> None:
         """Initialize a new Amplifier instance."""
-        super().__init__(active_ptt, rf_ptt_pin, pa_power_pin)
-        self.tr_relay = sd.assert_out(GPIOPin(tr_relay_pin, None, initial=None))
-        self.lna = sd.assert_out(GPIOPin(lna_pin, None, initial=None))
-        self.polarization = sd.assert_out(GPIOPin(polarization_pin, None, initial=None))
+        super().__init__(active_ptt, section)
+        self.tr_relay = sd.assert_out(
+            GPIOPin(int(sd.config[section]['tr_relay_pin']), None, initial=None)
+        )
+        self.lna = sd.assert_out(GPIOPin(int(sd.config[section]['lna_pin']), None, initial=None))
+        self.polarization = sd.assert_out(
+            GPIOPin(int(sd.config[section]['polarization_pin']), None, initial=None)
+        )
 
     def device_status(self, command: list[str]) -> str:
         p_state = 'LEFT' if self.polarization.read() == LEFT else 'RIGHT'
@@ -217,14 +218,7 @@ class VHF(RxTxAmplifier):
 
         Sets up the VHF amplifier with all its GPIO control pins.
         """
-        super().__init__(
-            active_ptt,
-            rf_ptt_pin=int(sd.config['VHF']['rf_ptt_pin']),
-            pa_power_pin=int(sd.config['VHF']['pa_power_pin']),
-            tr_relay_pin=int(sd.config['VHF']['tr_relay_pin']),
-            lna_pin=int(sd.config['VHF']['lna_pin']),
-            polarization_pin=int(sd.config['VHF']['polarization_pin']),
-        )
+        super().__init__(active_ptt, 'VHF')
 
 
 class UHF(RxTxAmplifier):
@@ -240,14 +234,7 @@ class UHF(RxTxAmplifier):
 
         Sets up the UHF amplifier with all its GPIO control pins.
         """
-        super().__init__(
-            active_ptt,
-            rf_ptt_pin=int(sd.config['UHF']['rf_ptt_pin']),
-            pa_power_pin=int(sd.config['UHF']['pa_power_pin']),
-            tr_relay_pin=int(sd.config['UHF']['tr_relay_pin']),
-            lna_pin=int(sd.config['UHF']['lna_pin']),
-            polarization_pin=int(sd.config['UHF']['polarization_pin']),
-        )
+        super().__init__(active_ptt, 'UHF')
 
 
 class LBand(TxAmplifier):
@@ -268,8 +255,4 @@ class LBand(TxAmplifier):
         Note: L-Band amplifier does not include TR relay, LNA, or polarization
               controls.
         """
-        super().__init__(
-            active_ptt,
-            rf_ptt_pin=int(sd.config['L-BAND']['rf_ptt_pin']),
-            pa_power_pin=int(sd.config['L-BAND']['pa_power_pin']),
-        )
+        super().__init__(active_ptt, 'L-BAND')

--- a/src/stationd/amplifier.py
+++ b/src/stationd/amplifier.py
@@ -6,7 +6,6 @@ from .gpio.gpio import HIGH, LOW, GPIOPin
 MOLLY_TIME = 20  # In seconds
 PTT_COOLDOWN = 120  # In seconds
 SLEEP_TIMER = 0.1
-PTT_MAX_COUNT = 1
 
 LEFT = HIGH
 RIGHT = LOW
@@ -32,14 +31,6 @@ class PTTCooldownError(Exception):
         self.seconds = seconds
 
 
-class MaxPTTError(Exception):
-    """Exception raised when maximum PTT connections are exceeded.
-
-    Prevents exceeding the configured maximum number of simultaneous PTT
-    connections.
-    """
-
-
 class TxAmplifier:
     """Controls for a TX only amplifier.
 
@@ -47,79 +38,69 @@ class TxAmplifier:
     That have a RF PTT (Push-To-Talk) switch and a power amplifier (PA).
     """
 
-    def __init__(self, rf_ptt_pin: int, pa_power_pin: int) -> None:
+    def __init__(self, active_ptt: 'sd.ActivePTT', rf_ptt_pin: int, pa_power_pin: int) -> None:
         """Initialize a new Amplifier instance."""
+        self.active_ptt = active_ptt
         self.rf_ptt = sd.assert_out(GPIOPin(rf_ptt_pin, None, initial=None))
         self.pa_power = sd.assert_out(GPIOPin(pa_power_pin, None, initial=None))
 
         self.molly_guard_time = time.time() - MOLLY_TIME
         self.ptt_off_time = time.time() - PTT_COOLDOWN
 
-    def device_status(self, command_obj: 'sd.Command') -> None:
-        status = (
-            f'{command_obj.command[0]} rf-ptt {sd.get_state(self.rf_ptt)}\n'
-            f'{command_obj.command[0]} pa-power {sd.get_state(self.pa_power)}\n'
+    def device_status(self, command: list[str]) -> str:
+        return (
+            f'{command[0]} rf-ptt {sd.get_state(self.rf_ptt)}\n'
+            f'{command[0]} pa-power {sd.get_state(self.pa_power)}\n'
         )
-        sd.status_response(command_obj, status)
 
-    def component_status(self, command_obj: 'sd.Command') -> None:
+    def component_status(self, command: list[str]) -> str:
         try:
-            component = getattr(self, command_obj.command[1].replace('-', '_'))
+            component = getattr(self, command[1].replace('-', '_'))
         except AttributeError as error:
-            raise sd.InvalidCommandError(command_obj) from error
+            raise sd.InvalidCommandError from error
 
-        status = sd.get_status(component, command_obj)
-        sd.status_response(command_obj, status)
+        return sd.get_status(component, command)
 
-    def molly_guard(self, command_obj: 'sd.Command') -> bool:
+    def check_molly_guard(self) -> None:
         if time.time() - self.molly_guard_time > MOLLY_TIME:
             self.molly_guard_time = time.time()
-            raise MollyGuardError(command_obj)
-        return True
+            raise MollyGuardError
 
-    def rf_ptt_on(self, command_obj: 'sd.Command') -> None:
+    def rf_ptt_on(self) -> None:
         if self.rf_ptt.read() == sd.ON:
             raise sd.NoChangeError
         if self.pa_power.read() == sd.OFF:
-            raise sd.PTTConflictError(command_obj)
-        if command_obj.num_active_ptt >= PTT_MAX_COUNT:
-            raise MaxPTTError(command_obj)
+            raise sd.PTTConflictError
 
         # brief cooldown
         time.sleep(SLEEP_TIMER)
+        self.active_ptt.inc()
         self.rf_ptt.write(sd.ON)
-        sd.success_response(command_obj)
-        command_obj.num_active_ptt += 1
 
-    def rf_ptt_off(self, command_obj: 'sd.Command') -> None:
+    def rf_ptt_off(self) -> None:
         if self.rf_ptt.read() == sd.OFF:
             raise sd.NoChangeError
         self.rf_ptt.write(sd.OFF)
-        sd.success_response(command_obj)
         #  set time ptt turned off
         self.ptt_off_time = time.time()
-        # make sure num_active_ptt never falls below 0
-        command_obj.num_active_ptt = max(command_obj.num_active_ptt - 1, 0)
+        self.active_ptt.dec()
 
-    def pa_power_on(self, command_obj: 'sd.Command') -> None:
+    def pa_power_on(self) -> None:
         if self.pa_power.read() == sd.ON:
             raise sd.NoChangeError
-        if self.molly_guard(command_obj):
-            self.pa_power.write(sd.ON)
-            sd.success_response(command_obj)
+        self.check_molly_guard()
+        self.pa_power.write(sd.ON)
 
-    def pa_power_off(self, command_obj: 'sd.Command') -> None:
+    def pa_power_off(self) -> None:
         if self.pa_power.read() == sd.OFF:
             raise sd.NoChangeError
         if self.rf_ptt.read() == sd.ON:
-            raise sd.PTTConflictError(command_obj)
+            raise sd.PTTConflictError
         #  Check PTT off for at least 2 minutes
         diff_sec = time.time() - self.ptt_off_time
-        if diff_sec > PTT_COOLDOWN:
-            self.pa_power.write(sd.OFF)
-            sd.success_response(command_obj)
-        else:
+        if diff_sec <= PTT_COOLDOWN:
             raise PTTCooldownError(round(PTT_COOLDOWN - diff_sec))
+        self.pa_power.write(sd.OFF)
 
 
 class RxTxAmplifier(TxAmplifier):
@@ -131,8 +112,9 @@ class RxTxAmplifier(TxAmplifier):
     polarization switching.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
+        active_ptt: 'sd.ActivePTT',
         rf_ptt_pin: int,
         pa_power_pin: int,
         tr_relay_pin: int,
@@ -140,49 +122,44 @@ class RxTxAmplifier(TxAmplifier):
         polarization_pin: int,
     ) -> None:
         """Initialize a new Amplifier instance."""
-        super().__init__(rf_ptt_pin, pa_power_pin)
+        super().__init__(active_ptt, rf_ptt_pin, pa_power_pin)
         self.tr_relay = sd.assert_out(GPIOPin(tr_relay_pin, None, initial=None))
         self.lna = sd.assert_out(GPIOPin(lna_pin, None, initial=None))
         self.polarization = sd.assert_out(GPIOPin(polarization_pin, None, initial=None))
 
-    def device_status(self, command_obj: 'sd.Command') -> None:
+    def device_status(self, command: list[str]) -> str:
         p_state = 'LEFT' if self.polarization.read() == LEFT else 'RIGHT'
-        status = (
-            f'{command_obj.command[0]} tr-relay {sd.get_state(self.tr_relay)}\n'
-            f'{command_obj.command[0]} rf-ptt {sd.get_state(self.rf_ptt)}\n'
-            f'{command_obj.command[0]} pa-power {sd.get_state(self.pa_power)}\n'
-            f'{command_obj.command[0]} lna {sd.get_state(self.lna)}\n'
-            f'{command_obj.command[0]} polarization {p_state}\n'
+        return super().device_status(command) + (
+            f'{command[0]} tr-relay {sd.get_state(self.tr_relay)}\n'
+            f'{command[0]} lna {sd.get_state(self.lna)}\n'
+            f'{command[0]} polarization {p_state}\n'
         )
-        sd.status_response(command_obj, status)
 
-    def component_status(self, command_obj: 'sd.Command') -> None:
-        if command_obj.command[1] == 'polarization':
+    def component_status(self, command: list[str]) -> str:
+        if command[1] == 'polarization':
             p_state = 'LEFT' if self.polarization.read() == LEFT else 'RIGHT'
-            status = f'{command_obj.command[0]} {command_obj.command[1]} {p_state}\n'
-            sd.status_response(command_obj, status)
-        else:
-            super().component_status(command_obj)
+            return f'{command[0]} {command[1]} {p_state}\n'
+        return super().component_status(command)
 
-    def rf_ptt_on(self, command_obj: 'sd.Command') -> None:
-        super().rf_ptt_on(command_obj)
+    def rf_ptt_on(self) -> None:
+        super().rf_ptt_on()
         # Enforce tr-relay and ptt are same state
         self.tr_relay_on()
         # Ptt command received, turn off LNA
         if self.lna.read() != sd.OFF:
             self.lna.write(sd.OFF)
 
-    def rf_ptt_off(self, command_obj: 'sd.Command') -> None:
-        super().rf_ptt_off(command_obj)
+    def rf_ptt_off(self) -> None:
+        super().rf_ptt_off()
         # Enforce tr-relay and ptt are same state
         self.tr_relay_off()
 
-    def pa_power_on(self, command_obj: 'sd.Command') -> None:
-        super().pa_power_on(command_obj)
+    def pa_power_on(self) -> None:
+        super().pa_power_on()
         self.tr_relay_on()
 
-    def pa_power_off(self, command_obj: 'sd.Command') -> None:
-        super().pa_power_off(command_obj)
+    def pa_power_off(self) -> None:
+        super().pa_power_off()
         self.tr_relay_off()
 
     def tr_relay_on(self) -> None:
@@ -195,40 +172,36 @@ class RxTxAmplifier(TxAmplifier):
             return
         self.tr_relay.write(sd.OFF)
 
-    def lna_on(self, command_obj: 'sd.Command') -> None:
+    def lna_on(self) -> None:
         if self.lna.read() == sd.ON:
             raise sd.NoChangeError
         #  Fail if PTT is on
         if self.rf_ptt.read() == sd.ON:
-            raise sd.PTTConflictError(command_obj)
+            raise sd.PTTConflictError
         self.lna.write(sd.ON)
-        sd.success_response(command_obj)
 
-    def lna_off(self, command_obj: 'sd.Command') -> None:
+    def lna_off(self) -> None:
         if self.lna.read() == sd.OFF:
             raise sd.NoChangeError
         self.lna.write(sd.OFF)
-        sd.success_response(command_obj)
 
-    def polarization_left(self, command_obj: 'sd.Command') -> None:
+    def polarization_left(self) -> None:
         if self.polarization.read() == LEFT:
             raise sd.NoChangeError
         if self.rf_ptt.read() == sd.ON:
-            raise sd.PTTConflictError(command_obj)
+            raise sd.PTTConflictError
         # brief cooldown
         time.sleep(SLEEP_TIMER)
         self.polarization.write(LEFT)
-        sd.success_response(command_obj)
 
-    def polarization_right(self, command_obj: 'sd.Command') -> None:
+    def polarization_right(self) -> None:
         if self.polarization.read() == RIGHT:
             raise sd.NoChangeError
         if self.rf_ptt.read() == sd.ON:
-            raise sd.PTTConflictError(command_obj)
+            raise sd.PTTConflictError
         # brief cooldown
         time.sleep(SLEEP_TIMER)
         self.polarization.write(RIGHT)
-        sd.success_response(command_obj)
 
 
 class VHF(RxTxAmplifier):
@@ -239,12 +212,13 @@ class VHF(RxTxAmplifier):
     frequency band operation.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, active_ptt: 'sd.ActivePTT') -> None:
         """Initialize the VHF amplifier.
 
         Sets up the VHF amplifier with all its GPIO control pins.
         """
         super().__init__(
+            active_ptt,
             rf_ptt_pin=int(sd.config['VHF']['rf_ptt_pin']),
             pa_power_pin=int(sd.config['VHF']['pa_power_pin']),
             tr_relay_pin=int(sd.config['VHF']['tr_relay_pin']),
@@ -261,12 +235,13 @@ class UHF(RxTxAmplifier):
     frequency band operation.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, active_ptt: 'sd.ActivePTT') -> None:
         """Initialize the UHF amplifier.
 
         Sets up the UHF amplifier with all its GPIO control pins.
         """
         super().__init__(
+            active_ptt,
             rf_ptt_pin=int(sd.config['UHF']['rf_ptt_pin']),
             pa_power_pin=int(sd.config['UHF']['pa_power_pin']),
             tr_relay_pin=int(sd.config['UHF']['tr_relay_pin']),
@@ -284,7 +259,7 @@ class LBand(TxAmplifier):
     polarization switching.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, active_ptt: 'sd.ActivePTT') -> None:
         """Initialize the L-Band amplifier.
 
         Sets up the L-Band amplifier with RF PTT and power amplifier GPIO
@@ -294,6 +269,7 @@ class LBand(TxAmplifier):
               controls.
         """
         super().__init__(
+            active_ptt,
             rf_ptt_pin=int(sd.config['L-BAND']['rf_ptt_pin']),
             pa_power_pin=int(sd.config['L-BAND']['pa_power_pin']),
         )

--- a/src/stationd/amplifier.py
+++ b/src/stationd/amplifier.py
@@ -1,16 +1,129 @@
 import time
-from multiprocessing import Manager
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from multiprocessing.managers import DictProxy
 
 from . import stationd as sd
-from .gpio.gpio import GPIOPin
+from .gpio.gpio import HIGH, LOW, GPIOPin
+
+MOLLY_TIME = 20  # In seconds
+PTT_COOLDOWN = 120  # In seconds
+SLEEP_TIMER = 0.1
+PTT_MAX_COUNT = 1
+
+LEFT = HIGH
+RIGHT = LOW
 
 
-class Amplifier:
-    """Base class for RF amplifier control systems.
+class MollyGuardError(Exception):
+    """Exception raised when molly guard protection is triggered.
+
+    Used to prevent accidental execution of potentially dangerous commands by
+    requiring confirmation within a time window.
+    """
+
+
+class PTTCooldownError(Exception):
+    """Exception raised when PTT cooldown period is not satisfied.
+
+    Enforces mandatory waiting period between PTT operations for hardware
+    protection.
+    """
+
+    def __init__(self, seconds: float) -> None:
+        """Initialize Push-to-Talk Cooldown exception."""
+        self.seconds = seconds
+
+
+class MaxPTTError(Exception):
+    """Exception raised when maximum PTT connections are exceeded.
+
+    Prevents exceeding the configured maximum number of simultaneous PTT
+    connections.
+    """
+
+
+class TxAmplifier:
+    """Controls for a TX only amplifier.
+
+    This class provides common functionality for controlling RF amplifiers
+    That have a RF PTT (Push-To-Talk) switch and a power amplifier (PA).
+    """
+
+    def __init__(self, rf_ptt_pin: int, pa_power_pin: int) -> None:
+        """Initialize a new Amplifier instance."""
+        self.rf_ptt = sd.assert_out(GPIOPin(rf_ptt_pin, None, initial=None))
+        self.pa_power = sd.assert_out(GPIOPin(pa_power_pin, None, initial=None))
+
+        self.molly_guard_time = time.time() - MOLLY_TIME
+        self.ptt_off_time = time.time() - PTT_COOLDOWN
+
+    def device_status(self, command_obj: 'sd.Command') -> None:
+        status = (
+            f'{command_obj.command[0]} rf-ptt {sd.get_state(self.rf_ptt)}\n'
+            f'{command_obj.command[0]} pa-power {sd.get_state(self.pa_power)}\n'
+        )
+        sd.status_response(command_obj, status)
+
+    def component_status(self, command_obj: 'sd.Command') -> None:
+        try:
+            component = getattr(self, command_obj.command[1].replace('-', '_'))
+        except AttributeError as error:
+            raise sd.InvalidCommandError(command_obj) from error
+
+        status = sd.get_status(component, command_obj)
+        sd.status_response(command_obj, status)
+
+    def molly_guard(self, command_obj: 'sd.Command') -> bool:
+        if time.time() - self.molly_guard_time > MOLLY_TIME:
+            self.molly_guard_time = time.time()
+            raise MollyGuardError(command_obj)
+        return True
+
+    def rf_ptt_on(self, command_obj: 'sd.Command') -> None:
+        if self.rf_ptt.read() == sd.ON:
+            raise sd.NoChangeError
+        if self.pa_power.read() == sd.OFF:
+            raise sd.PTTConflictError(command_obj)
+        if command_obj.num_active_ptt >= PTT_MAX_COUNT:
+            raise MaxPTTError(command_obj)
+
+        # brief cooldown
+        time.sleep(SLEEP_TIMER)
+        self.rf_ptt.write(sd.ON)
+        sd.success_response(command_obj)
+        command_obj.num_active_ptt += 1
+
+    def rf_ptt_off(self, command_obj: 'sd.Command') -> None:
+        if self.rf_ptt.read() == sd.OFF:
+            raise sd.NoChangeError
+        self.rf_ptt.write(sd.OFF)
+        sd.success_response(command_obj)
+        #  set time ptt turned off
+        self.ptt_off_time = time.time()
+        # make sure num_active_ptt never falls below 0
+        command_obj.num_active_ptt = max(command_obj.num_active_ptt - 1, 0)
+
+    def pa_power_on(self, command_obj: 'sd.Command') -> None:
+        if self.pa_power.read() == sd.ON:
+            raise sd.NoChangeError
+        if self.molly_guard(command_obj):
+            self.pa_power.write(sd.ON)
+            sd.success_response(command_obj)
+
+    def pa_power_off(self, command_obj: 'sd.Command') -> None:
+        if self.pa_power.read() == sd.OFF:
+            raise sd.NoChangeError
+        if self.rf_ptt.read() == sd.ON:
+            raise sd.PTTConflictError(command_obj)
+        #  Check PTT off for at least 2 minutes
+        diff_sec = time.time() - self.ptt_off_time
+        if diff_sec > PTT_COOLDOWN:
+            self.pa_power.write(sd.OFF)
+            sd.success_response(command_obj)
+        else:
+            raise PTTCooldownError(round(PTT_COOLDOWN - diff_sec))
+
+
+class RxTxAmplifier(TxAmplifier):
+    """Controls for a channel with both TX and RX amplifiers.
 
     This class provides common functionality for controlling RF amplifiers
     including transmit/receive relay control, RF PTT (Push-To-Talk), power
@@ -22,35 +135,18 @@ class Amplifier:
         self,
         rf_ptt_pin: int,
         pa_power_pin: int,
-        tr_relay_pin: int | None = None,
-        lna_pin: int | None = None,
-        polarization_pin: int | None = None,
+        tr_relay_pin: int,
+        lna_pin: int,
+        polarization_pin: int,
     ) -> None:
         """Initialize a new Amplifier instance."""
-        self.rf_ptt: GPIOPin = sd.assert_out(GPIOPin(rf_ptt_pin, None, initial=None))
-        self.pa_power: GPIOPin = sd.assert_out(GPIOPin(pa_power_pin, None, initial=None))
-        self.tr_relay: GPIOPin | None = (
-            sd.assert_out(GPIOPin(tr_relay_pin, None, initial=None))
-            if tr_relay_pin is not None
-            else None
-        )
-        self.lna: GPIOPin | None = (
-            sd.assert_out(GPIOPin(lna_pin, None, initial=None)) if lna_pin is not None else None
-        )
-        self.polarization: GPIOPin | None = (
-            sd.assert_out(GPIOPin(polarization_pin, None, initial=None))
-            if polarization_pin is not None
-            else None
-        )
-        self.molly_guard_time: float | None = None
-
-        # Shared data
-        self.manager = Manager()
-        self.shared: DictProxy[str, float] = self.manager.dict()
-        self.shared['ptt_off_time'] = time.time()
+        super().__init__(rf_ptt_pin, pa_power_pin)
+        self.tr_relay = sd.assert_out(GPIOPin(tr_relay_pin, None, initial=None))
+        self.lna = sd.assert_out(GPIOPin(lna_pin, None, initial=None))
+        self.polarization = sd.assert_out(GPIOPin(polarization_pin, None, initial=None))
 
     def device_status(self, command_obj: 'sd.Command') -> None:
-        p_state = 'LEFT' if sd.get_state(self.polarization) == 'ON' else 'RIGHT'
+        p_state = 'LEFT' if self.polarization.read() == LEFT else 'RIGHT'
         status = (
             f'{command_obj.command[0]} tr-relay {sd.get_state(self.tr_relay)}\n'
             f'{command_obj.command[0]} rf-ptt {sd.get_state(self.rf_ptt)}\n'
@@ -61,159 +157,81 @@ class Amplifier:
         sd.status_response(command_obj, status)
 
     def component_status(self, command_obj: 'sd.Command') -> None:
-        try:
-            component = getattr(self, command_obj.command[1].replace('-', '_'))
-            if command_obj.command[1] == 'polarization':
-                p_state = 'LEFT' if sd.get_state(self.polarization) == 'ON' else 'RIGHT'
-                status = f'{command_obj.command[0]} {command_obj.command[1]} {p_state}\n'
-                sd.status_response(command_obj, status)
-            else:
-                status = sd.get_status(component, command_obj)
-                sd.status_response(command_obj, status)
-        except AttributeError as error:
-            raise sd.InvalidCommandError(command_obj) from error
+        if command_obj.command[1] == 'polarization':
+            p_state = 'LEFT' if self.polarization.read() == LEFT else 'RIGHT'
+            status = f'{command_obj.command[0]} {command_obj.command[1]} {p_state}\n'
+            sd.status_response(command_obj, status)
+        else:
+            super().component_status(command_obj)
 
-    def molly_guard(self, command_obj: 'sd.Command') -> bool:
-        diff_sec = sd.calculate_diff_sec(self.molly_guard_time)
-        if diff_sec is None or diff_sec > 20:
-            self.molly_guard_time = time.time()
-            raise sd.MollyGuardError(command_obj)
-        # reset timer to none
-        self.molly_guard_time = None
-        return True
+    def rf_ptt_on(self, command_obj: 'sd.Command') -> None:
+        super().rf_ptt_on(command_obj)
+        # Enforce tr-relay and ptt are same state
+        self.tr_relay_on()
+        # Ptt command received, turn off LNA
+        if self.lna.read() != sd.OFF:
+            self.lna.write(sd.OFF)
+
+    def rf_ptt_off(self, command_obj: 'sd.Command') -> None:
+        super().rf_ptt_off(command_obj)
+        # Enforce tr-relay and ptt are same state
+        self.tr_relay_off()
+
+    def pa_power_on(self, command_obj: 'sd.Command') -> None:
+        super().pa_power_on(command_obj)
+        self.tr_relay_on()
+
+    def pa_power_off(self, command_obj: 'sd.Command') -> None:
+        super().pa_power_off(command_obj)
+        self.tr_relay_off()
 
     def tr_relay_on(self) -> None:
-        if self.tr_relay is None:
-            return
-        if self.tr_relay.read() is sd.ON:
+        if self.tr_relay.read() == sd.ON:
             return
         self.tr_relay.write(sd.ON)
 
     def tr_relay_off(self) -> None:
-        if self.tr_relay is None:
-            return
-        if self.tr_relay.read() is sd.OFF:
+        if self.tr_relay.read() == sd.OFF:
             return
         self.tr_relay.write(sd.OFF)
 
-    def rf_ptt_on(self, command_obj: 'sd.Command') -> None:
-        if self.rf_ptt.read() is sd.ON:
-            sd.no_change_response(command_obj)
-            return
-        if self.pa_power.read() is sd.OFF:
-            raise sd.PTTConflictError(command_obj)
-        if command_obj.num_active_ptt >= sd.PTT_MAX_COUNT:
-            raise sd.MaxPTTError(command_obj)
-        # Enforce tr-relay and ptt are same state
-        if self.tr_relay is not None:
-            self.tr_relay_on()
-
-        # Ptt command received, turn off LNA
-        if self.lna is not None:
-            self.lna_off(command_obj)
-        # brief cooldown
-        time.sleep(sd.SLEEP_TIMER)
-        self.rf_ptt.write(sd.ON)
-        sd.success_response(command_obj)
-        command_obj.num_active_ptt += 1
-
-    def rf_ptt_off(self, command_obj: 'sd.Command') -> None:
-        if self.rf_ptt.read() is sd.OFF:
-            sd.no_change_response(command_obj)
-            return
-        self.rf_ptt.write(sd.OFF)
-        sd.success_response(command_obj)
-        #  set time ptt turned off
-        self.shared['ptt_off_time'] = time.time()
-        command_obj.num_active_ptt -= 1
-        # make sure num_active_ptt never falls below 0
-        command_obj.num_active_ptt = max(command_obj.num_active_ptt, 0)
-        # Enforce tr-relay and ptt are same state
-        if self.tr_relay is not None:
-            self.tr_relay_off()
-
-    def pa_power_on(self, command_obj: 'sd.Command') -> None:
-        if self.pa_power.read() is sd.ON:
-            sd.no_change_response(command_obj)
-            return
-        if self.molly_guard(command_obj):
-            if self.tr_relay is not None:
-                self.tr_relay_on()
-            self.pa_power.write(sd.ON)
-            sd.success_response(command_obj)
-
-    def pa_power_off(self, command_obj: 'sd.Command') -> None:
-        if self.pa_power.read() is sd.OFF:
-            sd.no_change_response(command_obj)
-            return
-        if self.rf_ptt.read() is sd.ON:
-            raise sd.PTTConflictError(command_obj)
-        #  Check PTT off for at least 2 minutes
-        diff_sec = sd.calculate_diff_sec(self.shared['ptt_off_time'])
-        if diff_sec is not None and diff_sec > sd.PTT_COOLDOWN:
-            if self.tr_relay is not None:
-                self.tr_relay_off()
-            self.pa_power.write(sd.OFF)
-            sd.success_response(command_obj)
-        elif diff_sec is not None:
-            raise sd.PTTCooldownError(round(sd.PTT_COOLDOWN - diff_sec))
-        else:
-            raise sd.PTTCooldownError(round(sd.PTT_COOLDOWN))
-
     def lna_on(self, command_obj: 'sd.Command') -> None:
-        if self.lna is None:
-            raise sd.InvalidCommandError(command_obj)
-        if self.lna.read() is sd.ON:
-            sd.no_change_response(command_obj)
-            return
+        if self.lna.read() == sd.ON:
+            raise sd.NoChangeError
         #  Fail if PTT is on
-        if self.rf_ptt.read() is sd.ON:
+        if self.rf_ptt.read() == sd.ON:
             raise sd.PTTConflictError(command_obj)
         self.lna.write(sd.ON)
         sd.success_response(command_obj)
 
     def lna_off(self, command_obj: 'sd.Command') -> None:
-        if self.lna is None:
-            if command_obj.command[1] == 'lna':
-                raise sd.InvalidCommandError(command_obj)
-            return
-        # only send response if called directly via command
-        if self.lna.read() is sd.OFF and command_obj.command[1] == 'lna':
-            sd.no_change_response(command_obj)
-            return
+        if self.lna.read() == sd.OFF:
+            raise sd.NoChangeError
         self.lna.write(sd.OFF)
-        # only send response if called directly via command
-        if command_obj.command[1] == 'lna':
-            sd.success_response(command_obj)
+        sd.success_response(command_obj)
 
     def polarization_left(self, command_obj: 'sd.Command') -> None:
-        if self.polarization is None:
-            raise sd.InvalidCommandError(command_obj)
-        if self.polarization.read() is sd.LEFT:
-            sd.no_change_response(command_obj)
-            return
-        if self.rf_ptt.read() is sd.ON:
+        if self.polarization.read() == LEFT:
+            raise sd.NoChangeError
+        if self.rf_ptt.read() == sd.ON:
             raise sd.PTTConflictError(command_obj)
         # brief cooldown
-        time.sleep(sd.SLEEP_TIMER)
-        self.polarization.write(sd.LEFT)
+        time.sleep(SLEEP_TIMER)
+        self.polarization.write(LEFT)
         sd.success_response(command_obj)
 
     def polarization_right(self, command_obj: 'sd.Command') -> None:
-        if self.polarization is None:
-            raise sd.InvalidCommandError(command_obj)
-        if self.polarization.read() is sd.RIGHT:
-            sd.no_change_response(command_obj)
-            return
-        if self.rf_ptt.read() is sd.ON:
+        if self.polarization.read() == RIGHT:
+            raise sd.NoChangeError
+        if self.rf_ptt.read() == sd.ON:
             raise sd.PTTConflictError(command_obj)
         # brief cooldown
-        time.sleep(sd.SLEEP_TIMER)
-        self.polarization.write(sd.RIGHT)
+        time.sleep(SLEEP_TIMER)
+        self.polarization.write(RIGHT)
         sd.success_response(command_obj)
 
 
-class VHF(Amplifier):
+class VHF(RxTxAmplifier):
     """VHF amplifier control.
 
     Controls VHF band RF amplifier including transmit/receive relay, RF PTT,
@@ -235,7 +253,7 @@ class VHF(Amplifier):
         )
 
 
-class UHF(Amplifier):
+class UHF(RxTxAmplifier):
     """UHF amplifier control.
 
     Controls UHF band RF amplifier including transmit/receive relay, RF PTT,
@@ -257,7 +275,7 @@ class UHF(Amplifier):
         )
 
 
-class LBand(Amplifier):
+class LBand(TxAmplifier):
     """L-Band frequency amplifier control.
 
     Controls L-Band RF amplifier with RF PTT and power amplifier control.

--- a/src/stationd/amplifier.py
+++ b/src/stationd/amplifier.py
@@ -7,6 +7,7 @@ MOLLY_TIME = 20  # In seconds
 PTT_COOLDOWN = 120  # In seconds
 SLEEP_TIMER = 0.1
 
+# Polarization directions
 LEFT = HIGH
 RIGHT = LOW
 
@@ -17,6 +18,10 @@ class MollyGuardError(Exception):
     Used to prevent accidental execution of potentially dangerous commands by
     requiring confirmation within a time window.
     """
+
+    def __init__(self, seconds: float) -> None:
+        """Initialize Molly Guard exception."""
+        self.seconds = seconds
 
 
 class PTTCooldownError(Exception):
@@ -69,7 +74,7 @@ class TxAmplifier:
     def check_molly_guard(self) -> None:
         if time.time() - self.molly_guard_time > MOLLY_TIME:
             self.molly_guard_time = time.time()
-            raise MollyGuardError
+            raise MollyGuardError(MOLLY_TIME)
 
     def rf_ptt_on(self) -> None:
         if self.rf_ptt.read() == sd.ON:

--- a/src/stationd/stationd.py
+++ b/src/stationd/stationd.py
@@ -39,9 +39,9 @@ class MaxPTTError(Exception):
 
 
 class ActivePTT:
-    '''Thread safe counter for tracking simultaionous PTT activations.
+    '''Thread safe counter for tracking simultaneous PTT activations.
 
-    At most PTT_MAX_COUNT PTT lines scan be active at one time and this information needs to be
+    At most PTT_MAX_COUNT PTT lines can be active at one time and this information needs to be
     shared across all accessories and amplifiers.
     '''
 
@@ -135,8 +135,8 @@ class StationD:
                 message = f'FAIL: {" ".join(command)} PTT Conflict\n'
             except amp.PTTCooldownError as e:
                 message = f'WARNING: Please wait {e.seconds} seconds and try again\n'
-            except amp.MollyGuardError:
-                message = 'Re-enter the command within the next 20 seconds to proceed\n'
+            except amp.MollyGuardError as e:
+                message = f'Re-enter the command within the next {e.seconds} seconds to proceed\n'
             except MaxPTTError:
                 message = f'Fail: {" ".join(command)} Max PTT\n'
             except InvalidCommandError:

--- a/tests/test_stationd.py
+++ b/tests/test_stationd.py
@@ -11,5 +11,4 @@ class TestBasicFunctionality:
     def test_stationd_has_expected_attributes(self) -> None:
         """Test that stationd module has expected classes and constants."""
         assert hasattr(stationd, 'StationD')
-        assert hasattr(stationd, 'Command')
         assert hasattr(stationd, 'config')


### PR DESCRIPTION
I started out wanting to make a couple small changes to simplify `Accessory` and `Amplifier` but then things kind of spiraled from there. The big changes here are:
- The gpio pins are no longer optional in their devices so it no longer reports `N/A` for things. This simplified a lot of the device actions.
- Sending the actual response is pulled up into `command_handler` so now actions only have to return a string and then not think about how it gets delivered. With an extra `NoChangeError` (not really an error) added most actions could then also just do nothing on success or raise an exception on error and leave the actual string responses to be created up in `command_handler` itself.