### PR TITLE
Use dependency-groups, add module docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install .[dev]
+        python -m pip install . --group dev
     - name: Lint with Ruff
       run: |
         ruff check

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ These instructions assume you have Podman installed and configured.
 3.  Install dependencies (inside the container):
 
     ```sh
-    pip install -e .[dev]
+    pip install -e . --group dev
     ```
 
 ### For Raspberry Pi (Hardware)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,27 +12,25 @@ authors = [
     { name = "Steven Borrego" },
     { name = "Bryan Borgeson" }
 ]
+dynamic = ["version"]
 dependencies = [
     "gpiod>=2.3.0"
 ]
-dynamic = ["version"]
 
-[tool.setuptools.packages.find]
-where = ["src"]
-
-[tool.setuptools_scm]
-write_to = "src/stationd/_version.py"
-
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "sphinx",
     "mypy>=1.17.0",
     "pytest>=9.0.0",
     "pytest-cov>=7.0.0",
     "ruff>=0.12.5",
-    "setuptools>=80",
-    "setuptools-scm>=9",
 ]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools_scm]
+write_to = "src/stationd/_version.py"
 
 [tool.mypy]
 ignore_missing_imports = true
@@ -65,8 +63,6 @@ ignore = [
     "D300",    # triple-single-quotes
     "COM812",  # prohibited-trailing-comma
     "ISC001",  # single-line-implicit-string-concatenation
-    "D100",    # undocumented-public-module
-    "D101",    # undocumented-public-class
     "D102",    # undocumented-public-method
     # might leave off always. Does the user need to know __str__ makes a str?
     "D105",    # undocumented-magic-method
@@ -98,4 +94,13 @@ ignore = [
 "tests/**/test_*.py" = [
     "S101",      # assert - pytest prefers plain assert
     "PLC0415",   # import - pytests need flexibility around when to import
+    # The test modules are pretty self-describing, no need to enforce docstrings for them.
+    "D100",      # modules
+    "D101",      # classes
+    "D102",      # methods
+    "D103",      # functions
+    "D104",      # package
+    "D105",      # magic methods
+    "D106",      # nested classes
+    "D107",      # __init__
 ]

--- a/src/stationd/accessory.py
+++ b/src/stationd/accessory.py
@@ -1,3 +1,8 @@
+'''Accessories are things that can be enabled and disabled via a GPIO.
+
+Examples include relays, the radio host, SDR, and the rotator contorller.
+'''
+
 import gpiod
 
 from . import stationd as sd

--- a/src/stationd/amplifier.py
+++ b/src/stationd/amplifier.py
@@ -1,3 +1,10 @@
+'''Amplifiers are the high powered radio amplifiers with push-to-talk.
+
+There is typically one amplifier or an RX/TX pair per RF band. Care must be
+taken not to overheat or activate them in the wrong order as they can be
+physically damaged.
+'''
+
 import time
 
 import gpiod


### PR DESCRIPTION
The pyproject.toml table [dependency-groups] is relatively new and is intended for dependencies that shouldn't be referenced at all in the produced package, which makes it great for dev and testing things like ruff or pytest.

I've also enabled D100 and D101 Ruff lints to check for class and module docs, and added the missing ones where they were needed.

Finally I removed setuptools from the dev dependencies, as this is what setuptools recommends. The `build` tool will inspect [build-system].requires and fetch the packages then, which is the only time they should be needed.